### PR TITLE
MIC-2911: Make Process Detection to use Name, Not PID

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "[go]": {
+        "editor.formatOnSave": false,
+        "editor.codeActionsOnSave": {
+            "source.fixAll": false,
+            "source.organizeImports": false
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -261,3 +261,22 @@ supervisord service start
 supervisord service stop
 ```
 
+# Building from a Mac
+Install `golang`:
+```
+brew install go
+```
+
+Run the following commands to setup your repo:
+```
+# Maybe run the following?:
+# go generate ./...
+# go mod download
+go get github.com/mitchellh/gox
+go get github.com/tcnksm/ghr
+```
+
+Build the windows executable using the following:
+```
+CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -tags release -a -ldflags "-s -w" -o dist/supervisord_windows_amd64.exe
+```

--- a/process/process.go
+++ b/process/process.go
@@ -14,6 +14,9 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
 
 	"github.com/ochinchina/filechangemonitor"
 	"github.com/ochinchina/supervisord/config"
@@ -392,7 +395,15 @@ func (p *Process) getExitCodes() []int {
 func (p *Process) isRunning() bool {
 	if p.cmd != nil && p.cmd.Process != nil {
 		if runtime.GOOS == "windows" {
-			proc, err := os.FindProcess(p.cmd.Process.Pid)
+			procs, err := processes()
+			if err != nil {
+				log.Fatal(err)
+			}
+			foundProcess := findProcessByName(procs, filepath.Base(p.cmd.String()))
+			if foundProcess == nil {
+				return false
+			}
+			proc, err := os.FindProcess(foundProcess.ProcessID)
 			return proc != nil && err == nil
 		}
 		return p.cmd.Process.Signal(syscall.Signal(0)) == nil
@@ -914,4 +925,70 @@ func (p *Process) GetStatus() string {
 		return p.cmd.ProcessState.String()
 	}
 	return "running"
+}
+
+// TH32CS_SNAPPROCESS is described in https://msdn.microsoft.com/de-de/library/windows/desktop/ms682489(v=vs.85).aspx
+const TH32CS_SNAPPROCESS = 0x00000002
+
+// WindowsProcess is an implementation of Process for Windows.
+type WindowsProcess struct {
+	ProcessID       int
+	ParentProcessID int
+	Exe             string
+}
+
+func processes() ([]WindowsProcess, error) {
+	handle, err := windows.CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer windows.CloseHandle(handle)
+
+	var entry windows.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+	// get the first process
+	err = windows.Process32First(handle, &entry)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]WindowsProcess, 0, 50)
+	for {
+		results = append(results, newWindowsProcess(&entry))
+
+		err = windows.Process32Next(handle, &entry)
+		if err != nil {
+			// windows sends ERROR_NO_MORE_FILES on last process
+			if err == syscall.ERROR_NO_MORE_FILES {
+				return results, nil
+			}
+			return nil, err
+		}
+	}
+}
+
+func findProcessByName(processes []WindowsProcess, name string) *WindowsProcess {
+	for _, p := range processes {
+		if strings.ToLower(p.Exe) == strings.ToLower(name) {
+			return &p
+		}
+	}
+	return nil
+}
+
+func newWindowsProcess(e *windows.ProcessEntry32) WindowsProcess {
+	// Find when the string ends for decoding
+	end := 0
+	for {
+		if e.ExeFile[end] == 0 {
+			break
+		}
+		end++
+	}
+
+	return WindowsProcess{
+		ProcessID:       int(e.ProcessID),
+		ParentProcessID: int(e.ParentProcessID),
+		Exe:             syscall.UTF16ToString(e.ExeFile[:end]),
+	}
 }

--- a/process/process.go
+++ b/process/process.go
@@ -937,6 +937,7 @@ type WindowsProcess struct {
 	Exe             string
 }
 
+// Inspired by https://github.com/denisbrodbeck/how2readwindowsprocesses/blob/master/main.go
 func processes() ([]WindowsProcess, error) {
 	handle, err := windows.CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)
 	if err != nil {


### PR DESCRIPTION
https://ionpath.atlassian.net/browse/MIC-2911

## Testing
In order to test, the build exe currently exists on the test rack VM: `C:\Users\Ionpath\supervisord\supervisord_windows_amd64.exe`